### PR TITLE
Add --dc and --cloud flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ $ nethelp -v --log
 $ nethelp -l
 ```
 
+* Run tests only against a specific data center and cloud service
+```
+$ nethelp  --cloud vdc --api --dc na
+[✓] https://ondemand.saucelabs.com:443 is reachable 200 OK
+[✓] http://ondemand.saucelabs.com:80 is reachable 200 OK
+[✓] https://saucelabs.com/rest/v1/max.dobeck/tunnels is reachable 200 OK
+```
+
 ### Downloading and using
 Download the binary for your operating system at https://github.com/mdsauce/nethelp/releases.
 On Mac and Linux make this file executable by running `$ chmod 755`.  For example on a Linux machine:

--- a/README.md
+++ b/README.md
@@ -56,18 +56,16 @@ $ chmod 755 nethelp
 You may get a `permission denied` type error if you try and run without this step.
 
 ### Build
-Built using [Cobra](https://github.com/spf13/cobra) and go1.11.  Cobra is basically a templating tool for CLI and generator for the file structure. Cobra is built  on top of [pflag](https://github.com/spf13/pflag) which expands on the std library flag package in Go.
+Built using [Cobra](https://github.com/spf13/cobra) and go v1.11.  Cobra is an opinionated CLI generator. Cobra is built  on top of [pflag](https://github.com/spf13/pflag) which expands on the std library flag package in Go.
 
 1. Clone the repo.
 ```
 $ git clone git@github.com:mdsauce/nethelp.git
 ```
-2. Go the nethelp dir.  Use `go build` to build a local version in the current dir or `go install` to install one in the go/bin folder and add the binary to your path.
+2. Go the nethelp dir.  Use `$ go build` to build a local version in the current dir or `$ go install` to install one in the `~/go/bin` folder and add the `nethelp` binary to your path.
 
-If you're new to Go consider taking the tour https://tour.golang.org/list. 
+If you're new to Go consider taking the tour https://tour.golang.org/list.
 
 ### Next Features
-* run VDC or RDC tests only with a `cloud` flag
-* specify a data center, EU or US with a `dc` flag
 * create a test session with a specific name then quit it.  This will prove a connection can be made to the services and a test can start with user credentials.
 * recover from failures automatically, record the failure, then continue the rest of the tests.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,28 @@ Nethelp will assist with finding out what is blocking outbound connections from 
 ### Usage
 ```
 $ nethelp --help
+
+ ___  __ _ _   _  ___ ___   / / __   ___| |_| |__   ___| |_ __  
+/ __|/ _  | | | |/ __/ _ \ / / '_ \ / _ \ __| '_ \ / _ \ | '_ \ 
+\__ \ (_| | |_| | (_|  __// /| | | |  __/ |_| | | |  __/ | |_) |
+|___/\__,_|\__,_|\___\___/_/ |_| |_|\___|\__|_| |_|\___|_| .__/ 
+                                                         |_|  
+Nethelp will help find out what is blocking outbound 
+connections by sending requests to 
+services used during typical Sauce Labs usage.
+
 Usage:
   nethelp [flags]
 
 Flags:
       --api            run API tests.  Requires that you have $SAUCE_USERNAME and $SAUCE_ACCESS_KEY environment variables.
+      --cloud string   options are: VDC or RDC.  Select which services you'd like to test, Virtual Device Cloud or Real Device Cloud respectively. (default "all")
+      --dc string      options are: EU or NA.  Choose which data centers you want run diagnostics against, Europe or North America respectively. (default "all")
   -h, --help           help for nethelp
-      --http           run HTTP tests. Default is to run all tests.
       --log            enables logging to the file specified by the --out flag.
   -l, --lucky          disable the proxy check at startup and instead test the proxy during execution.
   -p, --proxy string   upstream proxy for nethelp to use. Enter like -p protocol://username:password@host:port
-      --tcp            run TCP tests. Default is to only run HTTP tests.
+      --tcp            run TCP tests. Will always run against all endpoints.
   -v, --verbose        print all logging levels
 ```
 * Default Usage will make HTTP and HTTPS connections to various endpoints

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ If you're new to Go consider taking the tour https://tour.golang.org/list.
 
 ### Next Features
 * create a test session with a specific name then quit it.  This will prove a connection can be made to the services and a test can start with user credentials.
-* recover from failures automatically, record the failure, then continue the rest of the tests.
+* recover from failures automatically, record the failure, then continue the rest of the diagnostics.

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ $ nethelp -l
 
 * Run tests only against a specific data center and cloud service
 ```
-$ nethelp  --cloud vdc --api --dc na
+$ nethelp  --cloud vdc --dc na
 [✓] https://ondemand.saucelabs.com:443 is reachable 200 OK
 [✓] http://ondemand.saucelabs.com:80 is reachable 200 OK
-[✓] https://saucelabs.com/rest/v1/max.dobeck/tunnels is reachable 200 OK
 ```
 
 ### Downloading and using

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,6 +136,8 @@ func init() {
 	// rootCmd.Flags().StringP("out", "o", time.Now().Format("20060102150405"), "optional output file for logging. Defaults to timestamp file in the current dir.  Only use if you want a custom log name.")
 	rootCmd.Flags().Bool("log", false, "enables logging to the file specified by the --out flag.")
 	rootCmd.Flags().Bool("api", false, "run API tests.  Requires that you have $SAUCE_USERNAME and $SAUCE_ACCESS_KEY environment variables.")
+	rootCmd.Flags().String("cloud","all", "Specify which cloud you would like to run diagnostics against.  Options are VDC or RDC.")
+	rootCmd.Flags().String("dc", "all", "Specify which continental data centers you want run diagnostics against.  Options are EU or DC.")
 
 	// http client settings
 	http.DefaultTransport = &http.Transport{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,13 @@ var sitelist, tcplist, vdcEndpoints, rdcEndpoints []string
 var rootCmd = &cobra.Command{
 	Use:   "nethelp",
 	Short: "Helper to troubleshoot problems running tests on Sauce Labs.",
-	Long: `Nethelp will assist with finding out what is blocking outbound 
+	Long: `
+ ___  __ _ _   _  ___ ___   / / __   ___| |_| |__   ___| |_ __  
+/ __|/ _  | | | |/ __/ _ \ / / '_ \ / _ \ __| '_ \ / _ \ | '_ \ 
+\__ \ (_| | |_| | (_|  __// /| | | |  __/ |_| | | |  __/ | |_) |
+|___/\__,_|\__,_|\___\___/_/ |_| |_|\___|\__|_| |_|\___|_| .__/ 
+                                                         |_|  
+	Nethelp will assist with finding out what is blocking outbound 
 connections from the machine by sending HTTP and TCP connections to 
 services used by Sauce Labs.`,
 	// Uncomment the following line if your bare application

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ services used during typical Sauce Labs usage.`,
 		rdcEU = []string{"https://eu1.appium.testobject.com/wd/hub/session"}
 		vdcRESTEndpoints := assembleVDCEndpoints()
 
+		// Collect the flags to decide which diagnostics to run
 		runTCP, err := cmd.Flags().GetBool("tcp")
 		if err != nil {
 			log.Fatal("Could not get the TCP flag. ", err)
@@ -98,13 +99,23 @@ services used during typical Sauce Labs usage.`,
 		if err != nil {
 			log.Fatal("Could not get the API flag. ", err)
 		}
+		whichDC, err := cmd.Flags().GetString("dc")
+		if err != nil {
+			log.Fatal("Could not get the dc flag. ", err)
+		}
+		whichCloud, err := cmd.Flags().GetString("cloud")
+		if err != nil {
+			log.Fatal("Could not get the cloud flag. ", err)
+		}
+
+		// Run the diagnostics that the user passed in
 		if runTCP {
 			diagnostics.TCPConns(tcplist, proxyURL)
 		}
 		if runAPI {
 			diagnostics.VdcAPI(vdcRESTEndpoints)
 		}
-		if runDefault(runTCP, runAPI) {
+		if runDefault(runTCP, runAPI) && whichDC == "all" && whichCloud == "all" {
 			diagnostics.PublicSites(sitelist)
 			diagnostics.SauceServices(vdcNA)
 			diagnostics.RDCServices(rdcEU)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,7 +112,7 @@ services used during typical Sauce Labs usage.`,
 		whichDC = strings.ToLower(whichDC)
 
 		// Run the diagnostics that the user passed in
-		if whichCloud != "all" {
+		if whichCloud != "all" && runAPI == false {
 			if whichCloud != "vdc" && whichCloud != "rdc" {
 				log.Fatal("The parameter is not valid.  Only all, vdc, or rdc is allowed. ", whichCloud)
 			}
@@ -200,7 +200,7 @@ func init() {
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.Flags().BoolP("lucky", "l", false, "disable the proxy check at startup and instead test the proxy during execution.")
-	rootCmd.Flags().Bool("tcp", false, "run TCP tests. Default is to only run HTTP tests.")
+	rootCmd.Flags().Bool("tcp", false, "run TCP tests. Will always run against all endpoints.")
 	// rootCmd.Flags().StringP("out", "o", time.Now().Format("20060102150405"), "optional output file for logging. Defaults to timestamp file in the current dir.  Only use if you want a custom log name.")
 	rootCmd.Flags().Bool("log", false, "enables logging to the file specified by the --out flag.")
 	rootCmd.Flags().Bool("api", false, "run API tests.  Requires that you have $SAUCE_USERNAME and $SAUCE_ACCESS_KEY environment variables.")

--- a/diagnostics/vdc_conns.go
+++ b/diagnostics/vdc_conns.go
@@ -10,9 +10,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// SauceServices sends HTTP requests to Sauce endpoints to prove
+// VDCServices sends HTTP requests to Sauce endpoints to prove
 // tests could theoretically be created and the data centers are reachable
-func SauceServices(sauceEndpoints []string) {
+func VDCServices(sauceEndpoints []string) {
 	for _, endpoint := range sauceEndpoints {
 		u, err := url.ParseRequestURI(endpoint)
 		if err != nil {
@@ -49,6 +49,7 @@ func SauceServices(sauceEndpoints []string) {
 // 2) api is reachable
 // 3) api retrieves the expected data if 1 & 2 are true
 func VdcAPI(vdcRESTEndpoints []string) {
+	log.Debug("Sending out HTTP reqs to these endpoints: ", vdcRESTEndpoints)
 	username := os.Getenv("SAUCE_USERNAME")
 	apiKey := os.Getenv("SAUCE_ACCESS_KEY")
 	for _, endpoint := range vdcRESTEndpoints {


### PR DESCRIPTION
Flags have been added for  both --dc and --cloud which can be used to specify which Service they want to connect to (VDC or RDC) or which Data Center (North America or Europe).

**Why**
Some users are RDC only and some are VDC only.  Others only have ports open to certain regions (for better or worse).  This should reduce confusion.