### PR TITLE
Add a simple server simulating idle connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ $ nethelp  --cloud vdc --dc na
 [✓] http://ondemand.saucelabs.com:80 is reachable 200 OK
 ```
 
+### Idle server
+
+The repository provides a custom http server simulating long idle connections. It can be found in `server/idle-server.go`.
+Usage:
+
+```
+$ cd server
+$ go build idle-server.go
+$ ./idle-server -p 8080 -v
+INFO[0000] Starting server, listening on port 8080
+```
+
+You can request specific timeouts in seconds the following way:
+
+```
+$ curl http://localhost:8080/10 # 10 seconds timeout
+$ curl http://localhost:8080/900 # 15 minutes timeout
+```
+
+The server will answer after the requested number of seconds, allowing to simulate long running idle connections.
+This is especially useful when trying to find out if long allocation time for RDC is a problem from a specific network.
+
 ### Build
 Built using [Cobra](https://github.com/spf13/cobra) and go v1.11.  Cobra is an opinionated CLI generator. Cobra is built  on top of [pflag](https://github.com/spf13/pflag) which expands on the std library flag package in Go.
 

--- a/server/idle-server.go
+++ b/server/idle-server.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "net/http"
+    "time"
+    "strconv"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		i, err := strconv.ParseInt(r.URL.Path[1:], 10, 32)
+		if err != nil {
+			log.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		log.Debug("Received request for a timeout of ", i, " seconds")
+
+		time.Sleep(time.Duration(i) * time.Second)
+		fmt.Fprintln(w, "Waited for", i, "seconds")
+		log.Debug("request answered after ", i, " seconds")
+	})
+}
+
+func main() {
+    port := flag.String("p", "8080", "port to listen to")
+    verbose := flag.Bool("v", false, "verbose mode")
+    flag.Parse()
+
+	log.SetLevel(log.WarnLevel)
+
+	s := &http.Server{
+		Addr:           fmt.Sprint(":", *port),
+		Handler:        handler(),
+		WriteTimeout:   20 * time.Minute,
+		IdleTimeout: 20 * time.Minute,
+	}
+
+	if *verbose {
+		log.SetLevel(log.TraceLevel)
+	}
+
+	log.Info("Starting server, listening on port ", *port)
+	log.Fatal(s.ListenAndServe())
+}


### PR DESCRIPTION
The idea is to provide a server that can simulate long allocation times like RDC.
The server takes an integer and will wait the number of seconds before replying.

I would be glad to see what you think @mdsauce. 🙂 